### PR TITLE
Fix CI: pin Poetry to 2.2.1 for Python 3.9, bump version to 0.3.3

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -21,6 +21,8 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
+          # Poetry >= 2.3 requires Python >= 3.10, but the matrix still tests 3.9
+          version: 2.2.1
           virtualenvs-create: true
           virtualenvs-in-project: true
       - name: Load cached venv

--- a/crawlerdetect/__init__.py
+++ b/crawlerdetect/__init__.py
@@ -3,4 +3,4 @@ from crawlerdetect.crawlerdetect import CrawlerDetect
 
 __all__ = ("CrawlerDetect", "providers", "__version__")
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "crawlerdetect"
-version = "0.3.2"
+version = "0.3.3"
 description = "CrawlerDetect is a Python library designed to identify bots, crawlers, and spiders by analyzing their user agents."
 authors = ["Vitalii Shishorin <moskrc@gmail.com>"]
 readme = "README.md"
@@ -74,7 +74,7 @@ allow_dirty = false
 commit = true
 message = "Bump version: {current_version} → {new_version}"
 commit_args = ""
-current_version = "0.3.2"
+current_version = "0.3.3"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 search = "{current_version}"


### PR DESCRIPTION
## What's Changed

- **Fix CI**: `snok/install-poetry@v1` installs the latest Poetry by default, and Poetry ≥ 2.3 requires Python ≥ 3.10, so the Python 3.9 matrix job failed at the "Install Poetry" step before tests could run. Poetry is now pinned to 2.2.1, the last version supporting Python 3.9.
- **Bump version**: 0.3.2 → 0.3.3 for the release that also includes the crawler database update to upstream v1.3.11 (#19).

CI is green on this branch (ubuntu-latest and macos-latest, Python 3.9): https://github.com/moskrc/crawlerdetect/actions/runs/27236678262

https://claude.ai/code/session_015p2r38chB3sCVL1kQAyctb

---
_Generated by [Claude Code](https://claude.ai/code/session_015p2r38chB3sCVL1kQAyctb)_